### PR TITLE
 レイアウトファイルの作成とエラーページの作成

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -8,3 +8,12 @@ import { NuxtLayout } from '#build/components';
   </div>
 </template>
 
+<script setup>
+  useHead({
+    title: "Nuxt3",
+    link: [{
+      rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Micro+5&family=Permanent+Marker&display=swap"
+    }]
+
+  })
+</script>

--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,10 @@
+
+import { NuxtLayout } from '#build/components';
 <template>
   <div>
-    <NuxtPage />
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
   </div>
 </template>
 

--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
-    <h1>Hello Nuxt3!!</h1>
+    <NuxtPage />
   </div>
 </template>
+

--- a/app.vue
+++ b/app.vue
@@ -11,9 +11,9 @@ import { NuxtLayout } from '#build/components';
 <script setup>
   useHead({
     title: "Nuxt3",
-    link: [{
-      rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Micro+5&family=Permanent+Marker&display=swap"
-    }]
-
-  })
+    link: [
+      {rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap"}
+    ]
+  }
+)
 </script>

--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-
-    <h1>Hello World</h1>
+    <h1>Hello Nuxt3!!</h1>
   </div>
 </template>

--- a/error.vue
+++ b/error.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="error.statusCode === 404">
-    <h1>404エラー！！</h1>
+    <h1>404エラー！</h1>
     <p>{{ error.message }}</p>
   </div>
 </template>

--- a/error.vue
+++ b/error.vue
@@ -1,0 +1,14 @@
+<template>
+  <div v-if="error.statusCode === 404">
+    <h1>404エラー！！</h1>
+    <p>{{ error.message }}</p>
+  </div>
+</template>
+
+<script setup>
+// エラーのステータスコードやエラーメッセージを取得する方法として useErrorを使用
+// 変数エラーはuseErrorでエラーのステータスコードやエラーメッセージを取得して代入
+
+const error = useError();
+  
+</script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="container">
+  <!-- 下記slotは、NuxtLayoutコンポーネントの子要素に差し代わる =レイアウトファイルからページを呼び出すにはslot が必要-->
+    <slot />
+    <footer>&copy; @kono</footer>
+  </div>
+</template>
+
+<style>
+  .container{
+    color: red;
+  }
+  footer {
+    background-color: orange;
+    color: wheat;
+    text-align: center;
+  }
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,4 +15,9 @@
     color: wheat;
     text-align: center;
   }
+
+  html{
+  font-family: "Micro 5", sans-serif;
+
+  }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -17,7 +17,7 @@
   }
 
   html{
-  font-family: "Micro 5", sans-serif;
+    font-family: 'Permanent Marker', cursive;
 
   }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h1>Top page</h1><hr>
+    <h1>Top Page</h1><hr>
     <NuxtLink to="/page1">Page1</NuxtLink ><br>
     <NuxtLink to="/page2">Page2</NuxtLink >
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <h1>Top page</h1><hr>
+    <NuxtLink to="/page1">Page1</NuxtLink ><br>
+    <NuxtLink to="/page2">Page2</NuxtLink >
+
+  </div>
+</template>
+<script></script>

--- a/pages/page1.vue
+++ b/pages/page1.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <h1>Page1</h1><hr>
+    <NuxtLink to="/">Top Page</NuxtLink ><br>
+    <NuxtLink to="/page2">Page2</NuxtLink >
+
+
+  </div>
+</template>
+<script></script>

--- a/pages/page2.vue
+++ b/pages/page2.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <h1>Page2</h1><hr>
+    <NuxtLink to="/">Top Page</NuxtLink ><br>
+    <NuxtLink to="/page1">Page1</NuxtLink >
+
+  </div>
+</template>
+<script></script>

--- a/pages/price.vue
+++ b/pages/price.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Price</h1><hr>
+  </div>
+</template>

--- a/pages/price.vue
+++ b/pages/price.vue
@@ -1,5 +1,5 @@
 <template>
   <div>
-    <h1>Price</h1><hr>
+    <h1>Price ページへ</h1><hr>
   </div>
 </template>


### PR DESCRIPTION
# 7c9274c64ceac6bbd07344d3d1393f316c3aa69f
# 作業内容
ページの使い回しをできるようにする
Nuxt3におけるlayoutsディレクトリは、各ページに共通のレイアウトやスタイルを適用するために使用される
layoutsディレクトリ内のdefault.vueという名前のファイルは、特定のレイアウトが指定されていないすべてのページに適用されるデフォルトのレイアウトとして機能されるので便利

デフォルトで呼び出されるApp.vueでdefault.vueとpagesディレクトリ内の各ページのコンポーネントを呼び出す。

```
 % tree layouts
layouts
└── default.vue
% tree pages
pages
├── index.vue
├── page1.vue
├── page2.vue
└── price.vue
```
このレイアウトを呼び出して適応させるには、NuxtLayoutコンポーネントを使用
App.vue
```
  <div>
    <NuxtLayout>
      <NuxtPage />
    </NuxtLayout>
  </div>
```

<details>
  <summary>layouts/default.vue</summary>
  
```
<template>
  <div class="container">
  <!-- 下記slotは、NuxtLayoutコンポーネントの子要素に差し代わる =レイアウトファイルからページを呼び出すにはslot が必要-->
    <slot />
    <footer>&copy; @kono</footer>
  </div>
</template>

<style>
  .container{
    color: red;
  }
  footer {
    background-color: orange;
    color: wheat;
    text-align: center;
  }
</style>
```

</details>
NuxtLayoutコンポーネントで、default.vueレイアウトを呼び出して、
<slot />にはNuxtLayoutコンポーネントの子要素、今回では<NuxtPage />が差し込まれる

https://github.com/kb8864/Study-Notes/assets/128299525/01d6f45f-a715-4823-955d-80c9303fecd2

default.vueに定義した内容が全てのページに適応されている

## エラーページの作成
ルートにerror.vueファイルを設置することで、この404ページを表示をerror.vueファイルにできる
また、ステータスコードによる条件分岐や、エラーメッセージの表示例もできる
<details>
  <summary>error.vue</summary>
  
```
<template>
  <div v-if="error.statusCode === 404">
    <h1>404エラー！！</h1>
    <p>{{ error.message }}</p>
  </div>
</template>

<script setup>
// エラーのステータスコードやエラーメッセージを取得する方法として useErrorを使用
// 変数エラーはuseErrorでエラーのステータスコードやエラーメッセージを取得して代入

const error = useError();
  
</script>
```

</details>

![スクリーンショット 2024-03-04 19 55 49](https://github.com/kb8864/Study-Notes/assets/128299525/af33e856-4fcd-4539-a062-3fe53d13ebd6)


# head情報の設定
Nuxt3ではuseHead()を使用することで、ページやコンポーネントのhead情報を設定できる
app.vueを編集
