### PR TITLE
Nuxt3のビューについての学習

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -8,3 +8,12 @@ import { NuxtLayout } from '#build/components';
   </div>
 </template>
 
+<script setup>
+  useHead({
+    title: "Nuxt3",
+    link: [{
+      rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Micro+5&family=Permanent+Marker&display=swap"
+    }]
+
+  })
+</script>

--- a/app.vue
+++ b/app.vue
@@ -11,9 +11,9 @@ import { NuxtLayout } from '#build/components';
 <script setup>
   useHead({
     title: "Nuxt3",
-    link: [{
-      rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Micro+5&family=Permanent+Marker&display=swap"
-    }]
-
-  })
+    link: [
+      {rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap"}
+    ]
+  }
+)
 </script>

--- a/error.vue
+++ b/error.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="error.statusCode === 404">
-    <h1>404エラー！！</h1>
+    <h1>404エラー！</h1>
     <p>{{ error.message }}</p>
   </div>
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,4 +15,9 @@
     color: wheat;
     text-align: center;
   }
+
+  html{
+  font-family: "Micro 5", sans-serif;
+
+  }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -17,7 +17,7 @@
   }
 
   html{
-  font-family: "Micro 5", sans-serif;
+    font-family: 'Permanent Marker', cursive;
 
   }
 </style>

--- a/pages/price.vue
+++ b/pages/price.vue
@@ -1,5 +1,5 @@
 <template>
   <div>
-    <h1>Price</h1><hr>
+    <h1>Price ページへ</h1><hr>
   </div>
 </template>


### PR DESCRIPTION
# ff5acb6bfebf3f6a443e65cb12c05245628f9794

# 作業内容

## nuxt3-viewフォルダを作成
## 共通レイアウトを適応するlayoutsディレクトリ作成

Nuxt3におけるlayoutsディレクトリは、各ページに共通のレイアウトやスタイルを適用するために使用
```
layouts
└ default.vue
```


```
<template>
  <div class="container">
  <!-- 下記slotは、NuxtLayoutコンポーネントの子要素に差し代わる =レイアウトファイルからページを呼び出すにはslot が必要-->
    <slot />
    <footer>&copy; @kono</footer>
  </div>
</template>
```

## head情報の設定

Nuxt3ではuseHead()を使用することで、ページやコンポーネントのhead情報を設定が可能


app.vueファイルを下記のように修正し、titleとGoogle Fontsの設定を起こった

```
<script setup>
  useHead({
    title: "Nuxt3",
    link: [
      {rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap"}
    ]
  }
)
</script>
```